### PR TITLE
Use local variables to scope plugin

### DIFF
--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -6,25 +6,29 @@ if [[ "${BUILDKITE_PLUGIN_TERRAFORM_PROVIDER_DEBUG:-false}" =~ (true|on|1) ]]; t
   set -x
 fi
 
-OWNER="${BUILDKITE_PLUGIN_TERRAFORM_PROVIDER_REPO%/*}"
-REPO="${BUILDKITE_PLUGIN_TERRAFORM_PROVIDER_REPO#*/}"
-VERSION="${BUILDKITE_PLUGIN_TERRAFORM_PROVIDER_VERSION}"
-ARCH="${BUILDKITE_PLUGIN_TERRAFORM_PROVIDER_ARCH:-linux_amd64}"
+function buildkite_plugin_terraform_provider() {
+  local OWNER="${BUILDKITE_PLUGIN_TERRAFORM_PROVIDER_REPO%/*}"
+  local REPO="${BUILDKITE_PLUGIN_TERRAFORM_PROVIDER_REPO#*/}"
+  local VERSION="${BUILDKITE_PLUGIN_TERRAFORM_PROVIDER_VERSION}"
+  local ARCH="${BUILDKITE_PLUGIN_TERRAFORM_PROVIDER_ARCH:-linux_amd64}"
 
-echo "--- Getting ${REPO}@${VERSION} :terraform: plugin from :github:"
-URL=$(
-  curl -sL "https://api.github.com/repos/${OWNER}/${REPO}/releases" |
-    jq -r '.[].assets[].browser_download_url' |
-    grep "${ARCH}" |
-    grep "${VERSION}"
-)
+  echo "--- Getting ${REPO}@${VERSION} :terraform: plugin from :github:"
+  URL=$(
+    curl -sL "https://api.github.com/repos/${OWNER}/${REPO}/releases" |
+      jq -r '.[].assets[].browser_download_url' |
+      grep "${ARCH}" |
+      grep "${VERSION}"
+  )
 
-echo "Downloading plugin"
-curl -L "${URL}" -o "/tmp/${REPO}_${VERSION}.tar.gz"
+  echo "Downloading plugin"
+  curl -L "${URL}" -o "/tmp/${REPO}_${VERSION}.tar.gz"
 
-mkdir -p "${HOME}/.terraform.d/plugins"
+  mkdir -p "${HOME}/.terraform.d/plugins"
 
-tar -xzf "/tmp/${REPO}_${VERSION}.tar.gz" -C "${HOME}/.terraform.d/plugins"
+  tar -xzf "/tmp/${REPO}_${VERSION}.tar.gz" -C "${HOME}/.terraform.d/plugins"
 
-rm -f "/tmp/${REPO}_${VERSION}.tar.gz"
-echo "Installed ${REPO}@${VERSION}"
+  rm -f "/tmp/${REPO}_${VERSION}.tar.gz"
+  echo "Installed ${REPO}@${VERSION}"
+}
+
+buildkite_plugin_terraform_provider


### PR DESCRIPTION
## Why
As shown in this output: https://buildkite.com/coyainsurance/scala-akka-http-template-deploy/builds/6#cfc21878-4d8a-433f-a181-a855f2173f2d/220-227
because the variables are not set as local, they affect the build scope, which we dont want for this plugin.